### PR TITLE
Add space between text and price

### DIFF
--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -26,7 +26,7 @@ export default async function handler(req, res) {
             unit_amount: 1900,
             product_data: {
               name: "One-time Payment - $19",
-              description: "Premium 200+ WordPress themes and 400+ Plugins package",
+              description: "\n\nPremium 200+ WordPress themes and 400+ Plugins package",
             },
           },
           quantity: 1,


### PR DESCRIPTION
Add vertical spacing to the Stripe checkout product description to separate it from the price.

---
<a href="https://cursor.com/background-agent?bcId=bc-2afa40e3-9348-49af-94d6-b03c6bb2ac5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2afa40e3-9348-49af-94d6-b03c6bb2ac5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

