### PR TITLE
Adjust snippet spacing for price and text

### DIFF
--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -26,7 +26,7 @@ export default async function handler(req, res) {
             unit_amount: 1900,
             product_data: {
               name: "One-time Payment - $19",
-              description: "Premium 200+ WordPress themes and 400+ Plugins package",
+              description: "\n\nPremium 200+ WordPress themes and 400+ Plugins package",
             },
           },
           quantity: 1,


### PR DESCRIPTION
Add vertical spacing between the price and description on the Stripe Checkout page by inserting line breaks in the description text.

---
<a href="https://cursor.com/background-agent?bcId=bc-47ceedfd-56df-456f-91fe-50b220652c61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47ceedfd-56df-456f-91fe-50b220652c61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

