### PR TITLE
Add spacing to stripe checkout left side

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -33,7 +33,7 @@ const Hero = () => {
 
             <div className="flex flex-col sm:flex-row gap-4 mb-8">
               <Button variant="hero" size="xl" className="group" onClick={handleCheckout}>
-                One-time Payment -$19
+                One-time Payment - $19
               </Button>
               <Button variant="ghost" size="xl" className="text-primary-foreground hover:bg-primary-foreground/10">
                 View Demos


### PR DESCRIPTION
Add a space in the call-to-action button text for improved readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc8bc7cb-26e6-4db2-a33d-b17f826b3007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc8bc7cb-26e6-4db2-a33d-b17f826b3007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

